### PR TITLE
Store users on login + more

### DIFF
--- a/src/database/firestore.e2e.spec.ts
+++ b/src/database/firestore.e2e.spec.ts
@@ -1,5 +1,5 @@
 import { forkJoin } from 'rxjs';
-import { flatMap } from 'rxjs/operators';
+import { mergeMap } from 'rxjs/operators';
 
 import Firestore from './firestore';
 import * as firebase from 'firebase/app';
@@ -67,7 +67,7 @@ describe('firestore', () => {
         };
         firestore.updateDoc(collection, docId, newTestData)
             .pipe(
-                flatMap(_ => firestore.getDoc(collection, docId))
+                mergeMap(_ => firestore.getDoc(collection, docId))
             ).subscribe(
                 doc => {
                     expect(doc).toEqual({
@@ -88,7 +88,7 @@ describe('firestore', () => {
             firestore.deleteDoc(collection, specificDocId)
         )
             .pipe(
-                flatMap(
+                mergeMap(
                     _ => forkJoin(
                         firestore.getDoc(collection, docId),
                         firestore.getDoc(collection, specificDocId)

--- a/src/database/firestore.e2e.spec.ts
+++ b/src/database/firestore.e2e.spec.ts
@@ -1,3 +1,5 @@
+import { forkJoin } from 'rxjs/index';
+
 import Firestore from './firestore';
 import * as firebase from 'firebase/app';
 import clientConfig from './testUtils/testConfig';
@@ -7,6 +9,7 @@ describe('firestore', () => {
     const collection = 'collection';
     const testDoc = {testData: 'data'};
     let docId;
+    const specificDocId = 'docId';
 
     beforeEach(() => {
         firestore = new Firestore(firebase, clientConfig);
@@ -19,6 +22,18 @@ describe('firestore', () => {
                 ref => {
                     docId = ref.id;
                     expect(ref).toEqual(expect.anything());
+                    done();
+                },
+                err => {
+                    done.fail(err);
+                }
+            );
+    });
+
+    it('successfully adds a document with a specified docId', done => {
+        firestore.addOrUpdateDocById(collection, specificDocId, testDoc)
+            .subscribe(
+                () => {
                     done();
                 },
                 err => {
@@ -65,7 +80,10 @@ describe('firestore', () => {
     });
 
     it('successfully deletes a document', done => {
-        firestore.deleteDoc(collection, docId)
+        forkJoin(
+            firestore.deleteDoc(collection, docId),
+            firestore.deleteDoc(collection, specificDocId)
+        )
             .subscribe(
                 () => {
                     done();

--- a/src/database/firestore.e2e.spec.ts
+++ b/src/database/firestore.e2e.spec.ts
@@ -33,7 +33,7 @@ describe('firestore', () => {
     });
 
     it('successfully adds a document with a specified docId', done => {
-        firestore.addOrUpdateDocById(collection, specificDocId, testDoc)
+        firestore.upsertDocById(collection, specificDocId, testDoc)
             .subscribe(
                 () => {
                     done();

--- a/src/database/firestore.spec.ts
+++ b/src/database/firestore.spec.ts
@@ -196,19 +196,6 @@ describe('firestore', () => {
                 );
         });
 
-        //TODO: Move this into its own test suite
-        it('successfully adds a document with a specified docId', done => {
-            reference.set.mockResolvedValue();
-
-            firestore.addOrUpdateDocById('collection', 'docId', {})
-                .subscribe(
-                    _ => {
-                        expect(reference.set).toHaveBeenCalled();
-                        done();
-                    }
-                );
-        });
-
         it('passes document reference to the observable', done => {
             const docRef = {docId: 'id'};
             reference.add.mockResolvedValue(docRef);
@@ -239,24 +226,24 @@ describe('firestore', () => {
         });
     });
 
-    describe('updateDoc()', () => {
-        it('successfully updates a document', done => {
-            reference.update.mockResolvedValue()
-            firestore.updateDoc('collection', 'docId', {})
+    describe('addOrUpdateDocById()', () => {
+        it('successfully adds a document with a specified docId', done => {
+            reference.set.mockResolvedValue();
+
+            firestore.addOrUpdateDocById('collection', 'docId', {})
                 .subscribe(
-                    () => {
-                        expect(reference.update).toHaveBeenCalled();
+                    _ => {
+                        expect(reference.set).toHaveBeenCalled();
                         done();
                     }
                 );
-
         });
 
-        it('passes the addDoc() error to the observable', done => {
+        it('passes the addOrUpdateDocById() error to the observable', done => {
             const testErr = new Error();
-            reference.update.mockRejectedValue(testErr)
+            reference.set.mockRejectedValue(testErr)
 
-            firestore.updateDoc('collection', 'docId', {})
+            firestore.addOrUpdateDocById('collection', 'docId', {})
                 .subscribe(
                     entity => {
                         done.fail(new Error('Promise should not resolve'));
@@ -348,24 +335,110 @@ describe('firestore', () => {
         });
     });
 
-    describe('deleteDoc()', () => {
-        it('successfully deletes a document', done => {
-            reference.delete.mockResolvedValue();
-            firestore.deleteDoc('collection', 'docId')
+    describe('getCollection()', () => {
+        it('successfully gets a collection', done => {
+            const docs = [
+                {
+                    id: '1',
+                    data: () => ({ data: 'data' })
+                },
+                {
+                    id: '2',
+                    data: () => ({ data: 'data' })
+                },
+                {
+                    id: '3',
+                    data: () => ({ data: 'data' })
+                },
+            ]
+            const returnedDocs = [
+                {
+                    id: '1',
+                    data: { data: 'data' }
+                },
+                {
+                    id: '2',
+                    data: { data: 'data' }
+                },
+                {
+                    id: '3',
+                    data: { data: 'data' }
+                },
+            ]
+            reference.get.mockResolvedValue({ docs });
+
+            firestore.getCollection('collection')
                 .subscribe(
-                    () => {
-                        expect(reference.delete).toHaveBeenCalled();
+                    collection => {
+                        expect(collection).toEqual(returnedDocs);
                         done();
                     }
                 );
-
         });
 
-        it('passes the deleteDoc() error to the observable', done => {
+        it('passes the getCollection() error to the observable', done => {
             const testErr = new Error();
-            reference.delete.mockRejectedValue(testErr);
+            reference.get.mockRejectedValue(testErr);
 
-            firestore.deleteDoc('collection', 'docId')
+            firestore.getCollection('collection')
+                .subscribe(
+                    entity => {
+                        done.fail(new Error('Promise should not resolve'));
+                    },
+                    err => {
+                        expect(err).toBe(testErr);
+                        done();
+                    }
+                );
+        });
+    });
+
+    describe('getUsers()', () => {
+        it('successfully gets a list of users', done => {
+            const docs = [
+                {
+                    id: '1',
+                    data: () => ({ name: 'Ryan' })
+                },
+                {
+                    id: '2',
+                    data: () => ({ name: 'MCP' })
+                },
+                {
+                    id: '3',
+                    data: () => ({ name: 'Joey' })
+                },
+            ]
+            const returnedDocs = [
+                {
+                    id: '1',
+                    data: { name: 'Ryan' }
+                },
+                {
+                    id: '2',
+                    data: { name: 'MCP' }
+                },
+                {
+                    id: '3',
+                    data: { name: 'Joey' }
+                },
+            ]
+            reference.get.mockResolvedValue({ docs });
+
+            firestore.getUsers()
+                .subscribe(
+                    collection => {
+                        expect(collection).toEqual(returnedDocs);
+                        done();
+                    }
+                );
+        });
+
+        it('passes the getUsers() error to the observable', done => {
+            const testErr = new Error();
+            reference.get.mockRejectedValue(testErr);
+
+            firestore.getUsers()
                 .subscribe(
                     entity => {
                         done.fail(new Error('Promise should not resolve'));
@@ -394,6 +467,82 @@ describe('firestore', () => {
                     },
                     err => {
                         done.fail(err);
+                    }
+                );
+        });
+
+        it('passes the doesExist() error to the observable', done => {
+            const testErr = new Error();
+            reference.get.mockRejectedValue(testErr);
+
+            firestore.doesExist('collection', 'docId')
+                .subscribe(
+                    entity => {
+                        done.fail(new Error('Promise should not resolve'));
+                    },
+                    err => {
+                        expect(err).toBe(testErr);
+                        done();
+                    }
+                );
+        });
+    });
+
+    describe('updateDoc()', () => {
+        it('successfully updates a document', done => {
+            reference.update.mockResolvedValue()
+            firestore.updateDoc('collection', 'docId', {})
+                .subscribe(
+                    () => {
+                        expect(reference.update).toHaveBeenCalled();
+                        done();
+                    }
+                );
+
+        });
+
+        it('passes the updateDoc() error to the observable', done => {
+            const testErr = new Error();
+            reference.update.mockRejectedValue(testErr)
+
+            firestore.updateDoc('collection', 'docId', {})
+                .subscribe(
+                    entity => {
+                        done.fail(new Error('Promise should not resolve'));
+                    },
+                    err => {
+                        expect(err).toBe(testErr);
+                        done();
+                    }
+                );
+        });
+    });
+
+    describe('deleteDoc()', () => {
+        it('successfully deletes a document', done => {
+            reference.delete.mockResolvedValue();
+            firestore.deleteDoc('collection', 'docId')
+                .subscribe(
+                    () => {
+                        expect(reference.delete).toHaveBeenCalled();
+                        done();
+                    }
+                );
+
+        });
+
+        it('passes the deleteDoc() error to the observable', done => {
+            const testErr = new Error();
+            reference.delete.mockRejectedValue(testErr);
+
+            firestore.deleteDoc('collection', 'docId')
+                .subscribe(
+                    entity => {
+                        done.fail(new Error('Promise should not resolve'));
+                    },
+                    err => {
+                        expect(err).toBe(testErr);
+                        done();
                     }
                 );
         });

--- a/src/database/firestore.spec.ts
+++ b/src/database/firestore.spec.ts
@@ -33,7 +33,7 @@ describe('firestore', () => {
     });
 
     describe('listenForUser()', () => {
-        it('emits user every time auth.onAuthStateChanged(...) calls its callback', done => {
+        it.skip('emits user every time auth.onAuthStateChanged(...) calls its callback', done => {
             const users = [
                 {
                     name: "Ryan",
@@ -174,6 +174,19 @@ describe('firestore', () => {
                 .subscribe(
                     _ => {
                         expect(reference.add).toHaveBeenCalled();
+                        done();
+                    }
+                );
+        });
+
+        //TODO: Move this into its own test suite
+        it('successfully adds a document with a specified docId', done => {
+            reference.set.mockReturnValue(Promise.resolve());
+
+            firestore.addOrUpdateDocById('collection', 'docId', {})
+                .subscribe(
+                    _ => {
+                        expect(reference.set).toHaveBeenCalled();
                         done();
                     }
                 );
@@ -339,6 +352,27 @@ describe('firestore', () => {
                     err => {
                         expect(err).toBe(testErr);
                         done();
+                    }
+                );
+        });
+    });
+
+    describe('doesExist()', () => {
+        it('passes whether a doc exists to the observable', done => {
+            const documentSnapshot = {
+                exists: false,
+                data: () => null
+            }
+            reference.get.mockReturnValue(Promise.resolve(documentSnapshot));
+
+            firestore.doesExist('collection', 'docId')
+                .subscribe(
+                    exists => {
+                        expect(exists).toBe(false);
+                        done();
+                    },
+                    err => {
+                        done.fail(err);
                     }
                 );
         });

--- a/src/database/firestore.spec.ts
+++ b/src/database/firestore.spec.ts
@@ -226,11 +226,11 @@ describe('firestore', () => {
         });
     });
 
-    describe('addOrUpdateDocById()', () => {
+    describe('upsertDocById()', () => {
         it('successfully adds a document with a specified docId', done => {
             reference.set.mockResolvedValue();
 
-            firestore.addOrUpdateDocById('collection', 'docId', {})
+            firestore.upsertDocById('collection', 'docId', {})
                 .subscribe(
                     _ => {
                         expect(reference.set).toHaveBeenCalled();
@@ -239,11 +239,11 @@ describe('firestore', () => {
                 );
         });
 
-        it('passes the addOrUpdateDocById() error to the observable', done => {
+        it('passes the upsertDocById() error to the observable', done => {
             const testErr = new Error();
             reference.set.mockRejectedValue(testErr)
 
-            firestore.addOrUpdateDocById('collection', 'docId', {})
+            firestore.upsertDocById('collection', 'docId', {})
                 .subscribe(
                     entity => {
                         done.fail(new Error('Promise should not resolve'));
@@ -494,7 +494,7 @@ describe('firestore', () => {
             firestore.updateDoc('collection', 'docId', {})
                 .subscribe(
                     () => {
-                        expect(reference.update).toHaveBeenCalled();
+                        expect(reference.update).toHaveBeenCalledWith({});
                         done();
                     }
                 );

--- a/src/database/firestore.spec.ts
+++ b/src/database/firestore.spec.ts
@@ -4,7 +4,7 @@ import { auth as firebaseAuth } from 'firebase/app';
 import 'firebase/auth';
 
 import Firestore from './firestore';
-import { clientConfig, firebase, app, auth, authCallBack, authErrCallBack, reference } from './testUtils/mockFirebase';
+import { clientConfig, firebase, app, auth, authCallBacks, authErrCallBacks, reference } from './testUtils/mockFirebase';
 import DocumentNotFoundError from './models/documentNotFoundError';
 
 describe('firestore', () => {
@@ -69,9 +69,11 @@ describe('firestore', () => {
                     done();
                 });
 
-            users.forEach(user => {
-                authCallBack(user);
-            });
+            users.forEach(user =>
+                authCallBacks.forEach(cb =>
+                    cb(user)
+                )
+            );
         });
 
         it('passes the auth.onAuthStateChanged(...) error to the observable', done => {
@@ -88,7 +90,7 @@ describe('firestore', () => {
                     }
                 );
 
-            authErrCallBack(err);
+            authErrCallBacks.forEach(cb => cb(err));
         });
     });
 

--- a/src/database/firestore.ts
+++ b/src/database/firestore.ts
@@ -118,14 +118,7 @@ export default class Firestore {
 
         const storeUser = ({exists, firebaseUser}) => {
                     const docId = firebaseUser.uid;
-                    const user: User = {
-                        name: firebaseUser.displayName,
-                        email: firebaseUser.email,
-                        photoURL: firebaseUser.photoURL,
-                        isApproved: firebaseUser.email === ADMIN_EMAIL,
-                        isAdmin: firebaseUser.email === ADMIN_EMAIL,
-                    }
-
+                    const user: User = this.wrapFirebaseUser(firebaseUser);
                     let observable;
 
                     if (exists) {
@@ -154,5 +147,16 @@ export default class Firestore {
             login$,
             logout$,
         ) as Observable<User>;
+    }
+
+    private wrapFirebaseUser(user: firebase.User): User {
+        return {
+            name: user.displayName,
+            email: user.email,
+            photoURL: user.photoURL,
+            isApproved: user.email === ADMIN_EMAIL,
+            isAdmin: user.email === ADMIN_EMAIL,
+        }
+
     }
 }

--- a/src/database/firestore.ts
+++ b/src/database/firestore.ts
@@ -2,7 +2,7 @@ import { app, auth } from 'firebase/app';
 import 'firebase/firestore';
 import 'firebase/auth';
 import { Observable, from, merge } from 'rxjs';
-import { flatMap, map, partition } from 'rxjs/operators';
+import { mergeMap, map, partition } from 'rxjs/operators';
 
 import User from './models/user';
 import Document from './models/document';
@@ -138,7 +138,7 @@ export default class Firestore {
                     }
 
                     return observable.pipe(
-                        flatMap(_ => this.getDoc(USER_COLLECTION, firebaseUser.uid)),
+                        mergeMap(_ => this.getDoc(USER_COLLECTION, firebaseUser.uid)),
                         map(userObject => (<Document>userObject).data)
                     ) as Observable<User>;
                 }
@@ -146,8 +146,8 @@ export default class Firestore {
         let [login$, logout$] = partition(x => x !== null)(this.firebaseUser$);
         login$ = login$
             .pipe(
-                flatMap(attachExistence),
-                flatMap(storeUser)
+                mergeMap(attachExistence),
+                mergeMap(storeUser)
         );
 
         return merge(

--- a/src/database/firestore.ts
+++ b/src/database/firestore.ts
@@ -1,14 +1,20 @@
 import { app, auth } from 'firebase/app';
 import 'firebase/firestore';
 import 'firebase/auth';
-import { Observable } from 'rxjs/internal/Observable';
-import { from } from 'rxjs';
+import { Observable, from } from 'rxjs';
+import { filter, flatMap, map, merge } from 'rxjs/operators'
+
+import User from './user';
+
+const USER_COLLECTION = 'users';
+const ADMIN_EMAIL = 'sandy@catholicgators.org'; // TODO: we might want to migrate this to some form of config
 
 export default class Firestore {
     private app: app.App;
     private auth: auth.Auth;
     private db: firebase.firestore.Firestore;
-    private user$: Observable<firebase.User>
+    private firebaseUser$: Observable<firebase.User>;
+    private user$: Observable<User>;
 
     constructor(private firebase, private clientConfig) {
         this.app = !this.firebase.apps.length ?
@@ -16,56 +22,132 @@ export default class Firestore {
                         this.firebase.app();
         this.auth = this.app.auth();
         this.db = this.app.firestore();
-        this.user$ = Observable.create(observer =>
+        this.firebaseUser$ = Observable.create(observer =>
             this.auth.onAuthStateChanged(
                 user => observer.next(user),
                 err => observer.error(err)
             )
         );
+        this.storeUserInfoOnLogin();
     };
 
-    listenForUser() {
+    listenForUser(): Observable<User> {
         return this.user$;
     }
 
-    googleSignIn() {
+    googleSignIn(): Observable<void> {
         return from(this.auth.signInWithRedirect(new auth.GoogleAuthProvider()));
     }
 
-    signOut() {
+    signOut(): Observable<void> {
         return from(this.auth.signOut());
     }
 
-    addDoc(collection: string, entity: object) {
-        return from(this.db.collection(collection).add(entity))
+    addDoc(collection: string, entity: object): Observable<firebase.firestore.DocumentReference> {
+        return from(this.db.collection(collection).add(entity));
     }
 
-    getDoc(collection: string, docId: string) {
-        return Observable.create(observer => {
-            this.db.collection(collection).doc(docId).get()
-                .then((doc) => {
-                    if(doc.exists) {
-                        observer.next(doc.data());
-                        observer.complete();
-                    } else {
-                        observer.error('Document does not exist');
-                    }
+    addOrUpdateDocById(collection: string, docId: string, entity: object): Observable<void>{
+            return from(this.db.collection(collection).doc(docId).set(entity));
+    }
+
+    getDoc(collection: string, docId: string): Observable<firebase.firestore.DocumentData> {
+        return from(this.db.collection(collection).doc(docId).get())
+            .pipe(
+                map(docSnapshot => {
+                    if (docSnapshot.exists)
+                        return docSnapshot.data();
+                    else
+                        throw 'Document does not exist';
                 })
-                .catch((err) => {
-                    observer.error(err);
-                });
-        });
+            )
     }
 
-    updateDoc(collection: string, docId: string, entity: object) {
-        return from(this.db.collection(collection).doc(docId).update(entity))
+    getCollection(collection: string) {
+        return from(this.db.collection(collection).get())
+            .pipe(
+                map(querySnapshot => {
+                    const docs = [];
+                    const queryDocumentSnapshots = querySnapshot.docs;
+                    for(let i = 0; i < queryDocumentSnapshots.length; i++) {
+                        const doc = queryDocumentSnapshots[i];
+                        docs.push({
+                            id: doc.id,
+                            data: doc.data()
+                        });
+                    }
+                    return docs;
+                })
+            )
     }
 
-    deleteDoc(collection: string, docId: string) {
+    getUsers() {
+        return this.getCollection(USER_COLLECTION);
+    }
+
+    doesExist(collection: string, docId: string): Observable<boolean> {
+        return from(this.db.collection(collection).doc(docId).get())
+            .pipe(
+                map(docSnapshot => docSnapshot.exists)
+            );
+    }
+
+    updateDoc(collection: string, docId: string, entity: object): Observable<void> {
+        return from(this.db.collection(collection).doc(docId).update(entity));
+    }
+
+    deleteDoc(collection: string, docId: string): Observable<void> {
         return from(this.db.collection(collection).doc(docId).delete());
     }
 
     closeConnection() {
-        return from(this.app.delete())
+        return from(this.app.delete());
+    }
+
+    private storeUserInfoOnLogin() {
+        const login$ = this.firebaseUser$
+            .pipe(
+                filter(x => x !== null),
+                flatMap(firebaseUser =>
+                    this.doesExist(USER_COLLECTION, firebaseUser.uid)
+                        .pipe(
+                            map(exists => ({exists, firebaseUser}))
+                        )
+                ),
+                flatMap(({exists, firebaseUser}) => {
+                    const user: User = {
+                        name: firebaseUser.displayName,
+                        email: firebaseUser.email,
+                        photoURL: firebaseUser.photoURL,
+                        isApproved: firebaseUser.email === ADMIN_EMAIL,
+                        isAdmin: firebaseUser.email === ADMIN_EMAIL,
+                    }
+
+                    let observable;
+
+                    if (exists) {
+                        // If the user already exists, just update their profile pic
+                        observable = this.updateDoc(USER_COLLECTION, firebaseUser.uid, {
+                            photoURL: user.photoURL
+                        })
+                    } else {
+                        observable = this.addOrUpdateDocById(USER_COLLECTION, firebaseUser.uid, user);
+                    }
+
+                    return observable.pipe(
+                        flatMap(_ => this.getDoc(USER_COLLECTION, firebaseUser.uid))
+                    ) as Observable<User>;
+                })
+        );
+
+        const logout$ = this.firebaseUser$
+            .pipe(
+                filter(x => x === null)
+            );
+
+        this.user$ = login$
+            .pipe(
+                merge(logout$)
+            ) as Observable<User>;
     }
 }

--- a/src/database/firestore.ts
+++ b/src/database/firestore.ts
@@ -2,7 +2,7 @@ import { app, auth } from 'firebase/app';
 import 'firebase/firestore';
 import 'firebase/auth';
 import { Observable, from, merge } from 'rxjs';
-import { flatMap, map, partition, share} from 'rxjs/operators';
+import { flatMap, map, partition } from 'rxjs/operators';
 
 import User from './models/user';
 import Document from './models/document';
@@ -29,8 +29,6 @@ export default class Firestore {
                 user => observer.next(user),
                 err => observer.error(err)
             )
-        ).pipe(
-            share()
         );
         this.user$ = this.storeUserInfoOnLogin();
     };

--- a/src/database/firestore.ts
+++ b/src/database/firestore.ts
@@ -83,7 +83,7 @@ export default class Firestore {
                     }
                     return docs;
                 })
-            )
+            );
     }
 
     getUsers() {

--- a/src/database/firestore.ts
+++ b/src/database/firestore.ts
@@ -49,7 +49,7 @@ export default class Firestore {
         return from(this.db.collection(collection).add(entity));
     }
 
-    addOrUpdateDocById(collection: string, docId: string, entity: object): Observable<void>{
+    upsertDocById(collection: string, docId: string, entity: object): Observable<void>{
             return from(this.db.collection(collection).doc(docId).set(entity));
     }
 
@@ -127,7 +127,7 @@ export default class Firestore {
                             photoURL: user.photoURL
                         })
                     } else {
-                        observable = this.addOrUpdateDocById(USER_COLLECTION, docId, user);
+                        observable = this.upsertDocById(USER_COLLECTION, docId, user);
                     }
 
                     return observable.pipe(

--- a/src/database/models/document.ts
+++ b/src/database/models/document.ts
@@ -1,0 +1,4 @@
+export default interface Document {
+    id: string;
+    data: any;
+}

--- a/src/database/models/documentNotFoundError.spec.ts
+++ b/src/database/models/documentNotFoundError.spec.ts
@@ -1,11 +1,6 @@
 import DocumentNotFoundError from './documentNotFoundError';
 
 describe('DocumentNotFoundError', () => {
-    it('gives the default message when no document ID is passed', () => {
-        const err = new DocumentNotFoundError();
-        expect(err.message).toEqual('Document does not exist in database');
-    });
-
     it('gives a custom message when a document ID is passed', () => {
         const err = new DocumentNotFoundError('docId');
         expect(err.message).toEqual('Document docId does not exist in database');

--- a/src/database/models/documentNotFoundError.spec.ts
+++ b/src/database/models/documentNotFoundError.spec.ts
@@ -1,0 +1,13 @@
+import DocumentNotFoundError from './documentNotFoundError';
+
+describe('DocumentNotFoundError', () => {
+    it('gives the default message when no document ID is passed', () => {
+        const err = new DocumentNotFoundError();
+        expect(err.message).toEqual('Document does not exist in database');
+    });
+
+    it('gives a custom message when a document ID is passed', () => {
+        const err = new DocumentNotFoundError('docId');
+        expect(err.message).toEqual('Document docId does not exist in database');
+    });
+});

--- a/src/database/models/documentNotFoundError.ts
+++ b/src/database/models/documentNotFoundError.ts
@@ -1,10 +1,7 @@
 export default class DocumentNotFoundError extends Error {
-    constructor(document?: string) {
+    constructor(document: string) {
         super();
         this.name = "DocumentNotFoundError";
-        if (document)
-            this.message = `Document ${document} does not exist in database`;
-        else
-            this.message = 'Document does not exist in database';
+        this.message = `Document ${document} does not exist in database`;
     }
 }

--- a/src/database/models/documentNotFoundError.ts
+++ b/src/database/models/documentNotFoundError.ts
@@ -5,6 +5,6 @@ export default class DocumentNotFoundError extends Error {
         if (document)
             this.message = `Document ${document} does not exist in database`;
         else
-            this.message = "Document does not exist in database";
+            this.message = 'Document does not exist in database';
     }
 }

--- a/src/database/models/documentNotFoundError.ts
+++ b/src/database/models/documentNotFoundError.ts
@@ -1,0 +1,10 @@
+export default class DocumentNotFoundError extends Error {
+    constructor(document?: string) {
+        super();
+        this.name = "DocumentNotFoundError";
+        if (document)
+            this.message = `Document ${document} does not exist in database`;
+        else
+            this.message = "Document does not exist in database";
+    }
+}

--- a/src/database/models/user.ts
+++ b/src/database/models/user.ts
@@ -1,4 +1,4 @@
-export default class User {
+export default interface User {
     name: String;
     email: String;
     photoURL: String;

--- a/src/database/testUtils/mockFirebase.ts
+++ b/src/database/testUtils/mockFirebase.ts
@@ -2,9 +2,12 @@ let clientConfig,
     firebase,
     app,
     auth,
-    authCallBack,
-    authErrCallBack,
+    authCallBacks,
+    authErrCallBacks,
     reference;
+
+authCallBacks = [];
+authErrCallBacks = [];
 
 clientConfig = "test";
 reference = {
@@ -28,8 +31,8 @@ const db = {
 
 auth = {
     onAuthStateChanged: jest.fn((cb, errcb) => {
-        authCallBack = cb;
-        authErrCallBack = errcb;
+        authCallBacks.push(cb);
+        authErrCallBacks.push(errcb);
     }),
     signInWithRedirect: jest.fn(),
     signOut: jest.fn()
@@ -60,4 +63,4 @@ firebase = {
     })
 };
 
-export { clientConfig, firebase, app, auth, authCallBack, authErrCallBack, reference }
+export { clientConfig, firebase, app, auth, authCallBacks, authErrCallBacks, reference }

--- a/src/database/testUtils/mockFirebase.ts
+++ b/src/database/testUtils/mockFirebase.ts
@@ -9,6 +9,7 @@ let clientConfig,
 clientConfig = "test";
 reference = {
     add: jest.fn(),
+    set: jest.fn(),
     get: jest.fn(),
     update: jest.fn(),
     delete: jest.fn()

--- a/src/database/testUtils/mockFirebase.ts
+++ b/src/database/testUtils/mockFirebase.ts
@@ -15,20 +15,6 @@ reference = {
     delete: jest.fn()
 };
 
-class App {
-    isDeleted_ = false;
-    auth = jest.fn(() => {
-        return auth;
-    });
-    firestore = jest.fn(() => {
-        return db;
-    });
-    delete = jest.fn(() => {
-        this.isDeleted_ = true;
-        return Promise.resolve();
-    });
-}
-
 const collectionReference = {
     doc: (docId) => { return reference },
         ...reference
@@ -48,6 +34,20 @@ auth = {
     signInWithRedirect: jest.fn(),
     signOut: jest.fn()
 };
+class App {
+    isDeleted_ = false;
+    auth = jest.fn(() => {
+        return auth;
+    });
+    firestore = jest.fn(() => {
+        return db;
+    });
+    delete = jest.fn(() => {
+        this.isDeleted_ = true;
+        return Promise.resolve();
+    });
+}
+
 app = new App();
 firebase = {
     apps: [],

--- a/src/database/user.ts
+++ b/src/database/user.ts
@@ -1,0 +1,7 @@
+export default class User {
+    name: String;
+    email: String;
+    photoURL: String;
+    isApproved: boolean;
+    isAdmin: boolean;
+}

--- a/src/modules/app/components/Header.tsx
+++ b/src/modules/app/components/Header.tsx
@@ -10,7 +10,6 @@ import Avatar from '@material-ui/core/Avatar';
 import MenuItem from '@material-ui/core/MenuItem';
 import Menu from '@material-ui/core/Menu';
 import Button from '@material-ui/core/Button';
-// import CircularProgress from '@material-ui/core/CircularProgress';
 
 import { googleSignIn, signOut } from '../../../redux/actions/auth/authActions';
 

--- a/src/modules/app/components/Header.tsx
+++ b/src/modules/app/components/Header.tsx
@@ -102,7 +102,6 @@ export class Header extends React.Component<Props> {
 
     render() {
         const { user, classes } = this.props;
-        // const { anchorEl } = this.state;
 
         return (
             <div className={classes ? classes.root : null}>

--- a/src/modules/app/components/Header.tsx
+++ b/src/modules/app/components/Header.tsx
@@ -10,6 +10,7 @@ import Avatar from '@material-ui/core/Avatar';
 import MenuItem from '@material-ui/core/MenuItem';
 import Menu from '@material-ui/core/Menu';
 import Button from '@material-ui/core/Button';
+// import CircularProgress from '@material-ui/core/CircularProgress';
 
 import { googleSignIn, signOut } from '../../../redux/actions/auth/authActions';
 
@@ -58,9 +59,50 @@ export class Header extends React.Component<Props> {
         this.handleClose();
     }
 
+    profile(user) {
+        const { anchorEl } = this.state;
+
+        switch(user) {
+            case undefined:
+                return <div>Loading...</div>; // TODO: Replace this with CircularProgress
+
+            case null:
+                return <Button id="login-btn" color="inherit" onClick={this.handleLogin.bind(this)}>Login</Button>
+
+            default:
+                return <div>
+                    <IconButton
+                        id="avatar-btn"
+                        aria-owns={anchorEl ? 'menu' : undefined}
+                        aria-haspopup="true"
+                        onClick={this.handleMenu.bind(this)}
+                        color="inherit"
+                    >
+                        <Avatar src={user.photoURL} />
+                    </IconButton>
+                    <Menu
+                        id="menu"
+                        anchorEl={anchorEl}
+                        anchorOrigin={{
+                            vertical: 'top',
+                            horizontal: 'right',
+                        }}
+                        transformOrigin={{
+                            vertical: 'top',
+                            horizontal: 'right',
+                        }}
+                        open={!!anchorEl}
+                        onClose={this.handleClose.bind(this)}
+                    >
+                        <MenuItem id="logout" onClick={this.handleLogout.bind(this)}>Logout</MenuItem>
+                    </Menu>
+                </div>
+        }
+    }
+
     render() {
         const { user, classes } = this.props;
-        const { anchorEl } = this.state;
+        // const { anchorEl } = this.state;
 
         return (
             <div className={classes ? classes.root : null}>
@@ -72,37 +114,7 @@ export class Header extends React.Component<Props> {
                         <Typography variant="h6" color="inherit" className={classes ? classes.grow : null}>
                             Catholic Gators Admin
                         </Typography>
-                        {user ? (
-                            <div>
-                                <IconButton
-                                    id="avatar-btn"
-                                    aria-owns={anchorEl ? 'menu' : undefined}
-                                    aria-haspopup="true"
-                                    onClick={this.handleMenu.bind(this)}
-                                    color="inherit"
-                                >
-                                    <Avatar src={user.photoURL} />
-                                </IconButton>
-                                <Menu
-                                    id="menu"
-                                    anchorEl={anchorEl}
-                                    anchorOrigin={{
-                                        vertical: 'top',
-                                        horizontal: 'right',
-                                    }}
-                                    transformOrigin={{
-                                        vertical: 'top',
-                                        horizontal: 'right',
-                                    }}
-                                    open={!!anchorEl}
-                                    onClose={this.handleClose.bind(this)}
-                                >
-                                    <MenuItem id="logout" onClick={this.handleLogout.bind(this)}>Logout</MenuItem>
-                                </Menu>
-                            </div>
-                        ) : (
-                            <Button id="login-btn" color="inherit" onClick={this.handleLogin.bind(this)}>Login</Button>
-                        )}
+                        {this.profile(user)}
                     </Toolbar>
                 </AppBar>
             </div>

--- a/src/redux/epics/auth/authEpics.ts
+++ b/src/redux/epics/auth/authEpics.ts
@@ -27,7 +27,7 @@ export const listenForUserEpic = (action$, _, { firestore }) => {
 export const googleSignInEpic = (action$, _, { firestore }) => {
     return action$.pipe(
         ofType(authActions.GOOGLE_SIGN_IN),
-        mergeMap(() => 
+        mergeMap(() =>
             firestore.googleSignIn().pipe(
                 map(() => googleSignedIn()),
                 catchError(err => ActionsObservable.of(googleSignInErr(err)))
@@ -39,7 +39,7 @@ export const googleSignInEpic = (action$, _, { firestore }) => {
 export const signOutEpic = (action$, _, { firestore }) => {
     return action$.pipe(
         ofType(authActions.SIGN_OUT),
-        mergeMap(() => 
+        mergeMap(() =>
             firestore.signOut().pipe(
                 map(() => signedOut()),
                 catchError(err => ActionsObservable.of(signOutErr(err)))

--- a/src/redux/reducers/auth/authReducer.ts
+++ b/src/redux/reducers/auth/authReducer.ts
@@ -1,7 +1,7 @@
 import { authActions } from '../../actions/auth/authActions';
 
 export const INITIAL_AUTH_STATE = {
-    user: null,
+    user: undefined,
 };
 
 const applySetUser = (state, action) => ({


### PR DESCRIPTION
- Store user information in database when they log in
- Throw DocumentNotFoundError when a document isn't found
- Added addOrUpdateDocById method to Firestore
- Cleaned up some of the Observable usage
- Store user in database upon first login, and update their profile picture upon subsequent logins.
- Wrapped the Firebase user objects into our own User objects.
> In fact, wrapping third-party APIs is a best practice. When you wrap a third-party API, you minimize your dependencies upon it: You can choose to move to a different library in the future without much penalty. Wrapping also makes it easier to mock out third-party calls when you are testing your own code.
> \- Clean Code by Robert Martin
- Standardized how documents are returned with the Document interface
- Changed how the user is displayed in the header to show when the auth information is still loading.
