### PR TITLE
Refactor users service

### DIFF
--- a/src/database/doc.ts
+++ b/src/database/doc.ts
@@ -1,3 +1,0 @@
-export default interface Doc {
-    id: string
-}

--- a/src/database/docNotFoundError.spec.ts
+++ b/src/database/docNotFoundError.spec.ts
@@ -1,4 +1,4 @@
-import DocNotFoundError from './docNotFoundError'
+import { DocNotFoundError } from './firestoreAdapter'
 
 describe('DocumentNotFoundError', () => {
     it('gives a custom message when a collection name and document id is passed', () => {

--- a/src/database/docNotFoundError.ts
+++ b/src/database/docNotFoundError.ts
@@ -1,7 +1,0 @@
-export default class DocNotFoundError extends Error {
-    constructor(collectionName: string, docId: string) {
-        super()
-        this.name = "DocumentNotFoundError"
-        this.message = `Document id ${docId} does not exist in collection ${collectionName}`
-    }
-}

--- a/src/database/firestoreAdapter.e2e.spec.ts
+++ b/src/database/firestoreAdapter.e2e.spec.ts
@@ -1,11 +1,8 @@
-import FirestoreAdapter from './firestoreAdapter'
-import Doc from './doc'
-import DocNotFoundError from './docNotFoundError'
+import FirestoreAdapter, { Doc, DocNotFoundError } from './firestoreAdapter'
 import * as firebase from 'firebase/app'
 import clientConfig from '../config/testClientConfig'
 
 interface TestInterface extends Doc {
-    id: string,
     foo: String
 }
 

--- a/src/database/firestoreAdapter.spec.ts
+++ b/src/database/firestoreAdapter.spec.ts
@@ -1,11 +1,8 @@
 import { when } from 'jest-when'
 
-import FirestoreAdapter from './firestoreAdapter'
-import DocNotFoundError from './docNotFoundError'
-import Doc from './doc'
+import FirestoreAdapter, { Doc, DocNotFoundError } from './firestoreAdapter'
 
 interface TestInterface extends Doc {
-    id: string,
     foo: String
 }
 

--- a/src/database/firestoreAdapter.ts
+++ b/src/database/firestoreAdapter.ts
@@ -1,11 +1,20 @@
 import "firebase/firestore"
 
-import DocNotFoundError from "./docNotFoundError"
-import Doc from './doc'
-
 type QueryDocumentSnapshot = firebase.firestore.QueryDocumentSnapshot
 type Transaction = firebase.firestore.Transaction
 type DocumentReference = firebase.firestore.DocumentReference
+
+export class DocNotFoundError extends Error {
+    constructor(collectionName: string, docId: string) {
+        super()
+        this.name = "DocumentNotFoundError"
+        this.message = `Document id ${docId} does not exist in collection ${collectionName}`
+    }
+}
+
+export interface Doc {
+    id: string
+}
 
 export default class FirestoreAdapter {
     constructor(private db: firebase.firestore.Firestore) { }

--- a/src/modules/admin/modules/interests/components/Interests/Interests.tsx
+++ b/src/modules/admin/modules/interests/components/Interests/Interests.tsx
@@ -15,13 +15,11 @@ import {
     getInterests,
     addOption,
     addSection,
-    NewOptionReq,
-    NewSectionReq,
     updateOptionText
 } from '../../redux/actions/interestActions'
 import AddableTextField from './components/AddableTextField/AddableTextField'
 import EditableOptionRow from './components/EditableOptionRow/EditableOptionRow'
-import { Section } from '../../services/interestsService'
+import { Section, NewSectionReq, NewOptionReq } from '../../services/interestsService'
 
 export const styles = (theme: Theme) =>
     createStyles({
@@ -61,7 +59,7 @@ export type Props = {
 }
 
 type State = {
-    editingOptionId: any
+    editingOptionId: string
     addingSectionId: string
     isAddingSection: boolean
 }
@@ -89,13 +87,12 @@ export class Interests extends Component<Props, State> {
     addSection(text: string) {
         this.props.addSection({
             text,
-            position: this.props.interests.length,
-            options: []
+            position: this.props.interests.length
         })
         this.setState({ isAddingSection: false })
     }
 
-    beginEditingOption(optionId: any) {
+    beginEditingOption(optionId: string) {
         this.setState({
             ...defaultState,
             editingOptionId: optionId
@@ -106,7 +103,7 @@ export class Interests extends Component<Props, State> {
         this.setState(defaultState)
     }
 
-    deleteOption(sectionId: string, optionId: any) {
+    deleteOption(sectionId: string, optionId: string) {
         this.setState(defaultState)
     }
 
@@ -205,10 +202,10 @@ export class Interests extends Component<Props, State> {
                         ))}
                     </div>
                 ) : (
-                    <div className={classes.formLoadingContainer}>
-                        <CircularProgress size="60px" />
-                    </div>
-                )}
+                        <div className={classes.formLoadingContainer}>
+                            <CircularProgress size="60px" />
+                        </div>
+                    )}
                 {isAddingSection ? (
                     <div
                         id="add-section-input"
@@ -216,8 +213,8 @@ export class Interests extends Component<Props, State> {
                     >
                         <AddableTextField
                             isAdding={true}
-                            beginAdding={() => {}}
-                            cancelAdding={() => {}}
+                            beginAdding={() => { }}
+                            cancelAdding={() => { }}
                             onAdd={text => this.addSection(text)}
                         />
                     </div>

--- a/src/modules/admin/modules/interests/components/Interests/components/EditableOptionRow/EditableOptionRow.tsx
+++ b/src/modules/admin/modules/interests/components/Interests/components/EditableOptionRow/EditableOptionRow.tsx
@@ -24,11 +24,11 @@ export const styles = (theme: Theme) =>
 export type Props = {
     classes: any
     option: Option
-    editingOptionId: number
-    beginEditingOption: (optionId: any) => void
+    editingOptionId: string
+    beginEditingOption: (optionId: string) => void
     cancelEditingOption: () => void
-    deleteOption: (optionId: any) => void
-    saveOption: (optionId: any, newText: string) => void
+    deleteOption: (optionId: string) => void
+    saveOption: (optionId: string, newText: string) => void
 }
 
 export type State = {

--- a/src/modules/admin/modules/interests/redux/actions/interestActions.ts
+++ b/src/modules/admin/modules/interests/redux/actions/interestActions.ts
@@ -1,4 +1,4 @@
-import { Option, Section } from '../../services/interestsService'
+import { Option, Section, NewOptionReq, NewSectionReq } from '../../services/interestsService'
 
 export const interestActions = {
     GET_INTERESTS: 'GET_INTERESTS',
@@ -27,9 +27,6 @@ export function getInterestsErr(err: any) {
     return { type: interestActions.GET_INTERESTS_ERR, err }
 }
 
-export type NewOptionReq = {
-    text: string
-}
 export const addOption = (sectionId: string, option: NewOptionReq) => ({
     type: interestActions.ADD_OPTION,
     sectionId,
@@ -45,11 +42,6 @@ export const addOptionErr = err => ({
     err
 })
 
-export type NewSectionReq = {
-    text: string
-    position: number
-    options: Option[]
-}
 export const addSection = (section: NewSectionReq) => ({
     type: interestActions.ADD_SECTION,
     section

--- a/src/modules/admin/modules/interests/services/interestsService.spec.ts
+++ b/src/modules/admin/modules/interests/services/interestsService.spec.ts
@@ -1,7 +1,6 @@
 import { when } from 'jest-when'
 
-import InterestsService, { Section } from './interestsService'
-import { NewSectionReq, NewOptionReq } from '../redux/actions/interestActions'
+import InterestsService, { Section, NewOptionReq, NewSectionReq } from './interestsService'
 
 describe('InterestsService', () => {
     let service: InterestsService,
@@ -39,18 +38,21 @@ describe('InterestsService', () => {
     })
 
     describe('addSection', () => {
-        it('adds a section to the section collection and returns new section', async () => {
+        it('adds a section to the section collection and returns new section initialized with no options', async () => {
             const newSectionReq: NewSectionReq = {
                 position: 0,
-                text: 'test',
-                options: []
+                text: 'test'
             }
             const expectedSection: Section = {
                 ...newSectionReq,
-                id: 'id'
+                id: 'id',
+                options: []
             }
             when(adapter.add)
-                .calledWith(InterestsService.SECTIONS, newSectionReq)
+                .calledWith(InterestsService.SECTIONS, {
+                    ...newSectionReq,
+                    options: []
+                })
                 .mockResolvedValue(expectedSection)
 
             const result = await service.addSection(newSectionReq)

--- a/src/modules/admin/modules/interests/services/interestsService.ts
+++ b/src/modules/admin/modules/interests/services/interestsService.ts
@@ -1,25 +1,22 @@
-import 'firebase/firestore'
-import { NewOptionReq, NewSectionReq } from '../redux/actions/interestActions'
-import FirestoreAdapter from '../../../../../database/firestoreAdapter'
+import FirestoreAdapter, { Doc } from '../../../../../database/firestoreAdapter'
 
-type SectionDoc = {
-    id: string
+interface SectionData {
     text: string
     position: number
+}
+interface SectionDoc extends Doc, SectionData {
     options: string[]
 }
-
-export type Section = {
-    id: string
-    text: string
-    position: number
+export interface NewSectionReq extends SectionData { }
+export interface Section extends Doc, SectionData {
     options: Option[]
 }
 
-export type Option = {
-    id: any
+interface OptionData {
     text: string
 }
+export interface NewOptionReq extends OptionData { }
+export interface Option extends Doc, OptionData { }
 
 export default class InterestsService {
     public static readonly OPTIONS: string = 'options'
@@ -72,6 +69,9 @@ export default class InterestsService {
     }
 
     addSection(sectionReq: NewSectionReq): Promise<Section> {
-        return this.adapter.add<Section>(InterestsService.SECTIONS, sectionReq)
+        return this.adapter.add<Section>(InterestsService.SECTIONS, {
+            ...sectionReq,
+            options: []
+        })
     }
 }

--- a/src/modules/admin/modules/users/services/user.ts
+++ b/src/modules/admin/modules/users/services/user.ts
@@ -1,0 +1,9 @@
+import Document from '../../../../../models/document';
+
+export default interface User extends Document {
+    name: String;
+    email: String;
+    photoURL: String;
+    isApproved: boolean;
+    isAdmin: boolean;
+}

--- a/src/modules/admin/modules/users/services/user.ts
+++ b/src/modules/admin/modules/users/services/user.ts
@@ -1,9 +1,0 @@
-import Document from '../../../../../models/document';
-
-export default interface User extends Document {
-    name: String;
-    email: String;
-    photoURL: String;
-    isApproved: boolean;
-    isAdmin: boolean;
-}

--- a/src/modules/admin/modules/users/services/userService.spec.ts
+++ b/src/modules/admin/modules/users/services/userService.spec.ts
@@ -1,49 +1,35 @@
 import { when } from 'jest-when'
 
-import UserService from './userService'
+import UserService, { User } from './userService'
 
 describe('UserService', () => {
-    let service: UserService, db, usersCollection, user, userSnapshot, userRef
+    let service: UserService, adapter, user: User
 
     beforeEach(() => {
-        usersCollection = {
-            add: jest.fn(),
-            doc: jest.fn(),
+        adapter = {
             get: jest.fn()
         }
-        db = {
-            collection: jest.fn()
-        }
-        when(db.collection)
-            .calledWith(UserService.USERS)
-            .mockReturnValue(usersCollection)
-
         user = {
-            foo: 'bar'
-        }
-        userSnapshot = {
-            data: jest.fn(() => user)
-        }
-        userRef = {
-            id: 'userDocId',
-            get: jest.fn(() => userSnapshot)
+            id: 'userId',
+            email: 'email',
+            isAdmin: true,
+            isApproved: true,
+            name: 'test',
+            photoURL: 'url'
         }
 
-        service = new UserService(db)
+        service = new UserService(adapter)
     })
 
     describe('getUser', () => {
         it('gets the user', async () => {
-            when(usersCollection.doc)
-                .calledWith(userRef.id)
-                .mockReturnValue(userRef)
+            when(adapter.get)
+                .calledWith(UserService.USERS, user.id)
+                .mockReturnValue(user)
 
-            const user = await service.getUser(userRef.id)
+            const result = await service.getUser(user.id)
 
-            expect(user).toEqual({
-                id: userRef.id,
-                ...user
-            })
+            expect(result).toBe(user)
         })
     })
 })

--- a/src/modules/admin/modules/users/services/userService.spec.ts
+++ b/src/modules/admin/modules/users/services/userService.spec.ts
@@ -1,0 +1,49 @@
+import { when } from 'jest-when'
+
+import UserService from './userService'
+
+describe('UserService', () => {
+    let service: UserService, db, usersCollection, user, userSnapshot, userRef
+
+    beforeEach(() => {
+        usersCollection = {
+            add: jest.fn(),
+            doc: jest.fn(),
+            get: jest.fn()
+        }
+        db = {
+            collection: jest.fn()
+        }
+        when(db.collection)
+            .calledWith(UserService.USERS)
+            .mockReturnValue(usersCollection)
+
+        user = {
+            foo: 'bar'
+        }
+        userSnapshot = {
+            data: jest.fn(() => user)
+        }
+        userRef = {
+            id: 'userDocId',
+            get: jest.fn(() => userSnapshot)
+        }
+
+        service = new UserService(db)
+    })
+
+    describe('getUser', () => {
+        it('gets the user', async () => {
+            when(usersCollection.doc)
+                .calledWith(userRef.id)
+                .mockReturnValue(userRef)
+
+            const user = await service.getUser(userRef.id)
+
+            expect(user).toEqual({
+                id: userRef.id,
+                ...user
+            })
+        })
+    })
+})

--- a/src/modules/admin/modules/users/services/userService.ts
+++ b/src/modules/admin/modules/users/services/userService.ts
@@ -1,15 +1,17 @@
-import 'firebase/firestore'
+import FirestoreAdapter, { Doc } from '../../../../../database/firestoreAdapter'
 
-import User from './user'
-
-interface Doc {
-    id: string
+export interface User extends Doc {
+    name: String
+    email: String
+    photoURL: String
+    isApproved: boolean
+    isAdmin: boolean
 }
 
 export default class UserService {
     public static readonly USERS: string = 'users'
 
-    constructor(private db: firebase.firestore.Firestore) {}
+    constructor(private adapter: FirestoreAdapter) { }
 
     // addUser(user: User): Observable<User> {
     //     return this.docRefObservableToUserObservable(
@@ -24,7 +26,7 @@ export default class UserService {
     // }
 
     async getUser(id: string): Promise<User> {
-        return this.getAndFlatten(UserService.USERS, id)
+        return this.adapter.get<User>(UserService.USERS, id)
     }
 
     // getAllUsers(): Observable<User[]> {
@@ -94,19 +96,4 @@ export default class UserService {
     // deleteUsers(ids: string[]): Observable<void> {
     //     return this.db.deleteDocs(USER_COLLECTION, ids)
     // }
-
-    private async getAndFlatten<T extends Doc>(
-        collection: string,
-        id: string
-    ): Promise<T> {
-        const doc = await this.db
-            .collection(collection)
-            .doc(id)
-            .get()
-
-        return {
-            id: doc.id,
-            ...doc.data()
-        } as T
-    }
 }

--- a/src/modules/admin/modules/users/services/userService.ts
+++ b/src/modules/admin/modules/users/services/userService.ts
@@ -1,0 +1,112 @@
+import 'firebase/firestore'
+
+import User from './user'
+
+interface Doc {
+    id: string
+}
+
+export default class UserService {
+    public static readonly USERS: string = 'users'
+
+    constructor(private db: firebase.firestore.Firestore) {}
+
+    // addUser(user: User): Observable<User> {
+    //     return this.docRefObservableToUserObservable(
+    //         this.db.addDoc(USER_COLLECTION, user)
+    //     )
+    // }
+
+    // addUsers(users: User[]): Observable<User[]> {
+    //     return this.docRefsObservableToUsersObservable(
+    //         this.db.upsertDocs(USER_COLLECTION, users)
+    //     )
+    // }
+
+    async getUser(id: string): Promise<User> {
+        return this.getAndFlatten(UserService.USERS, id)
+    }
+
+    // getAllUsers(): Observable<User[]> {
+    //     return this.db.getCollection(USER_COLLECTION) as Observable<User[]>
+    // }
+
+    // updateUser(id: string, update: Object): Observable<User> {
+    //     return this.docRefObservableToUserObservable(
+    //         this.db.updateDoc(USER_COLLECTION, id, update)
+    //     )
+    // }
+
+    // updateUsers(users: User[]): Observable<User[]> {
+    //     return this.docRefsObservableToUsersObservable(
+    //         this.db.updateDocs(USER_COLLECTION, users)
+    //     )
+    // }
+
+    // updateUserApproval(id: string, isApproved: boolean): Observable<User> {
+    //     return this.docRefObservableToUserObservable(
+    //         this.db.updateDoc(USER_COLLECTION, id, {
+    //             isApproved
+    //         })
+    //     )
+    // }
+
+    // updateUsersApproval(
+    //     ids: string[],
+    //     isApproved: boolean
+    // ): Observable<User[]> {
+    //     const updates = ids.map(id => ({
+    //         id,
+    //         isApproved
+    //     }))
+
+    //     return this.docRefsObservableToUsersObservable(
+    //         this.db.updateDocs(USER_COLLECTION, updates)
+    //     )
+    // }
+
+    // updateUserAdminStatus(id: string, isAdmin: boolean): Observable<User> {
+    //     return this.docRefObservableToUserObservable(
+    //         this.db.updateDoc(USER_COLLECTION, id, {
+    //             isAdmin
+    //         })
+    //     )
+    // }
+
+    // updateUsersAdminStatus(
+    //     ids: string[],
+    //     isAdmin: boolean
+    // ): Observable<User[]> {
+    //     const updates = ids.map(id => ({
+    //         id,
+    //         isAdmin
+    //     }))
+
+    //     return this.docRefsObservableToUsersObservable(
+    //         this.db.updateDocs(USER_COLLECTION, updates)
+    //     )
+    // }
+
+    // deleteUser(id: string): Observable<void> {
+    //     return this.db.deleteDoc(USER_COLLECTION, id)
+    // }
+
+    // deleteUsers(ids: string[]): Observable<void> {
+    //     return this.db.deleteDocs(USER_COLLECTION, ids)
+    // }
+
+    private async getAndFlatten<T extends Doc>(
+        collection: string,
+        id: string
+    ): Promise<T> {
+        const doc = await this.db
+            .collection(collection)
+            .doc(id)
+            .get()
+
+        return {
+            id: doc.id,
+            ...doc.data()
+        } as T
+    }
+}

--- a/src/modules/contactForm/services/contactFormService.ts
+++ b/src/modules/contactForm/services/contactFormService.ts
@@ -1,8 +1,7 @@
-import 'firebase/firestore'
 import InterestsService, {
     Section
 } from '../../admin/modules/interests/services/interestsService'
-import FirestoreAdapter from '../../../database/firestoreAdapter'
+import FirestoreAdapter, { Doc } from '../../../database/firestoreAdapter'
 
 export const ContactStatus = {
     NOT_CALLED: 0,
@@ -10,7 +9,7 @@ export const ContactStatus = {
     CALLED: 4
 }
 
-export type NewContactReq = {
+interface ContactData {
     firstName: string
     lastName: string
     gender: string
@@ -31,29 +30,8 @@ export type NewContactReq = {
     status: number
     createdAt: Date
 }
-
-export type Contact = {
-    id: string
-    firstName: string
-    lastName: string
-    gender: string
-    email: string
-    phoneNumber: string
-    graduationSemester: string
-    graduationYear: string
-    school: string
-    permanentAddress: string
-    city: string
-    state: string
-    zipCode: string
-    housingComplex: string
-    parentName: string
-    parentPhone: string
-    parentEmail: string
-    interests: string[]
-    status: number
-    createdAt: Date
-}
+export interface NewContactReq extends ContactData { }
+export interface Contact extends Doc, ContactData { }
 
 export default class ContactFormService {
     public static readonly CONTACTS_COLLECTION: string = 'contacts'


### PR DESCRIPTION
This is a medium sized first PR for refactoring the users service. This concerns setting up the skeleton for the users service and refactoring code to better use proper OOP when defining data contracts for the database. More changes fleshing out the user service will come after this one.

Also I pulled the models for Doc and DocNotFound to be in the adapter because I felt the namespacing was clearer when importing.